### PR TITLE
Fix case dtypes are objects

### DIFF
--- a/metrics/map.py
+++ b/metrics/map.py
@@ -27,7 +27,7 @@ def _group_negcons(meta: pd.DataFrame):
     negcon_ix = (meta['Metadata_JCP2022'] == 'DMSO')
     n_negcon = negcon_ix.sum()
     negcon_ids = [f'DMSO_{i}' for i in range(n_negcon)]
-    pert_id = meta['Metadata_JCP2022'].cat.add_categories(negcon_ids)
+    pert_id = meta['Metadata_JCP2022'].astype("category").cat.add_categories(negcon_ids)
     pert_id[negcon_ix] = negcon_ids
     meta['Metadata_JCP2022'] = pert_id
 


### PR DESCRIPTION
I fixed a fringe case that occurs when dtypes are objects instead of categoricals (happened in the CRISPR profile set). This shouldn't have any relevant performance impact. My script ran fine afterwards so I guess that is it.